### PR TITLE
[BUGFIX] Adjust carousel node type example

### DIFF
--- a/Documentation/HowTos/IntegratingJavaScriptSlider.rst
+++ b/Documentation/HowTos/IntegratingJavaScriptSlider.rst
@@ -35,7 +35,7 @@ TypoScript (Sites/Vendor.Site/Resources/Private/TypoScript/NodeTypes/Carousel.ts
 	prototype(Vendor.Site:Carousel) {
 		carouselItems = TYPO3.Neos:ContentCollection {
 			nodePath = 'carouselItems'
-			iterationName = 'carouselItemsIteration'
+			content.iterationName = 'carouselItemsIteration'
 			attributes.class = 'carousel-inner'
 		}
 


### PR DESCRIPTION
Since Neos 2.0 you have to write content.iterationName instead of iterationName.