### PR TITLE
Fix wrong TS path in extending pages example

### DIFF
--- a/Documentation/HowTos/ExtendingPages.rst
+++ b/Documentation/HowTos/ExtendingPages.rst
@@ -32,7 +32,7 @@ in the below example:
 Fusion (Sites/Vendor.Site/Resources/Private/Fusion/Root.fusion) ::
 
 	prototype(Neos.Neos:Page) {
-		backgroundImage = ${q(node).property('backgroundImage')}
+		body.backgroundImage = ${q(node).property('backgroundImage')}
 	}
 
 With Neos.Media ViewHelper you can display the Image with the follwing HTML snippet:


### PR DESCRIPTION
Fix exception when following documentation about extending pages.
See detailed description and discussion https://discuss.neos.io/t/solved-extending-the-page-typo3-media-domain-model-image-could-not-be-converted-to-string/1952