### PR TITLE
Update user commands

### DIFF
--- a/Classes/Command/UserCommandController.php
+++ b/Classes/Command/UserCommandController.php
@@ -347,6 +347,48 @@ class UserCommandController extends CommandController
             }
         }
     }
+    
+    /**
+     * Remove a role from a user
+     *
+     * This command allows for removal of a specific role from an existing user.
+     *
+     * If an authentication provider was specified, the user will be determined by an account identified by "username"
+     * related to the given provider. However, once a user has been found, the role will be removed from <b>all</b>
+     * existing accounts related to that user, regardless of its authentication provider.
+     *
+     * @param string $username The username of the user (globbing is supported)
+     * @param string $role Role to be removed from the user, for example "Neos.Neos:Administrator" or just "Administrator"
+     * @param string $newRoleName Role to be removed from the user, for example "Neos.Neos:Administrator" or just "Administrator"
+     * @param string $authenticationProvider Name of the authentication provider to use. Example: "Neos.Neos:Backend"
+     *
+     * @return void
+     */
+    public function renameRoleCommand($username, $role, $newRoleName, $authenticationProvider = null)
+    {
+        $users = $this->findUsersByUsernamePattern($username, $authenticationProvider);
+        if (empty($users)) {
+            $this->outputLine('No users that match name-pattern "%s" do exist.', [$username]);
+            $this->quit(1);
+        }
+        
+        foreach ($users as $user) {
+            $username = $this->userService->getUsername($user, $authenticationProvider);
+            try {
+                if (in_array($role, $this->userService->getAllRoles($user))) {
+                    $this->userService->removeRoleFromUser($user, $role);
+                    $this->userService->addRoleToUser($user, $newRoleName);
+                    
+                    $this->outputLine('Renamed role "%s" to "%s" for user "%s".', [$role, $newRoleName, $username]);
+                } else {
+                    $this->outputLine('User "%s" did not have the role "%s" assigned.', [$username, $role]);
+                }
+            } catch (NoSuchRoleException $exception) {
+                $this->outputLine('The role "%s" does not exist.', [$role]);
+                $this->quit(2);
+            }
+        }
+    }
 
     /**
      * Find all users the match the given username with globbing support

--- a/Classes/Command/UserCommandController.php
+++ b/Classes/Command/UserCommandController.php
@@ -349,17 +349,17 @@ class UserCommandController extends CommandController
     }
     
     /**
-     * Remove a role from a user
+     * Rename a role in a user
      *
-     * This command allows for removal of a specific role from an existing user.
+     * This command allows for renaming of a specific role in an existing user.
      *
      * If an authentication provider was specified, the user will be determined by an account identified by "username"
-     * related to the given provider. However, once a user has been found, the role will be removed from <b>all</b>
+     * related to the given provider. However, once a user has been found, the role will be renamed in <b>all</b>
      * existing accounts related to that user, regardless of its authentication provider.
      *
      * @param string $username The username of the user (globbing is supported)
-     * @param string $role Role to be removed from the user, for example "Neos.Neos:Administrator" or just "Administrator"
-     * @param string $newRoleName Role to be removed from the user, for example "Neos.Neos:Administrator" or just "Administrator"
+     * @param string $role Role to be renamed in the user, for example "Neos.Neos:Administrator" or just "Administrator"
+     * @param string $newRoleName The new name for the role, for example "Neos.Neos:Administrator" or just "Administrator"
      * @param string $authenticationProvider Name of the authentication provider to use. Example: "Neos.Neos:Backend"
      *
      * @return void


### PR DESCRIPTION
Hello,

we've encountered a useCase for this functionality when a site and their associated policies and roles changed. We had to migrate our users' account-roles as just leaving them there could leave to safety hazards in the future if another role were to have the same identifier as one that has been previously deleted.

Best Regards,
Theodor